### PR TITLE
MarkerData Rewrite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,14 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
+bevy = { version = "0.9.1", optional = true }
 bevy_ecs = "0.9.1"
 bevy_ecs_markers_macros = { path = "macros", version = "0.1.4", optional = true }
 
 [features]
 default = ["proc"]
 proc = ["dep:bevy_ecs_markers_macros"]
+full_bevy = ["dep:bevy"]
 
 [dev-dependencies]
 bevy = "0.9.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_ecs_markers"
-version = "0.1.4"
+version = "1.0.0"
 edition = "2021"
 authors = ["DasLixou"]
 description = "🏷️ Markers for Bevy ECS Entities"
@@ -12,7 +12,7 @@ exclude = ["examples"]
 
 [dependencies]
 bevy_ecs = "0.9.1"
-bevy_ecs_markers_macros = { path = "macros", version = "0.1.4", optional = true }
+bevy_ecs_markers_macros = { path = "macros", version = "1.0.0", optional = true }
 bevy = { version = "0.9.1", optional = true }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,11 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-bevy = { version = "0.9.1", optional = true }
 bevy_ecs = "0.9.1"
 bevy_ecs_markers_macros = { path = "macros", version = "0.1.4", optional = true }
+bevy = { version = "0.9.1", optional = true }
 
 [features]
 default = ["proc"]
 proc = ["dep:bevy_ecs_markers_macros"]
 full_bevy = ["dep:bevy"]
-
-[dev-dependencies]
-bevy = "0.9.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/ChoppedStudio/bevy_ecs_markers"
 keywords = ["bevy"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
+exclude = ["examples"]
 
 [dependencies]
 bevy_ecs = "0.9.1"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ fn setup(
     let blue = commands.spawn(Player(7)).id();
     markers[Players::Blue] = blue;
 
-    *current = blue;
+    **current = blue;
 }
 
 fn get_red_player(mut query: Query<&mut Player>, markers: Marker<Players>) {
@@ -43,7 +43,7 @@ fn get_red_player(mut query: Query<&mut Player>, markers: Marker<Players>) {
 }
 
 fn get_current_player(mut query: Query<&mut Player>, current: Marker<CurrentPlayer>) {
-    if let Ok(mut player) = query.get_mut(*current) {
+    if let Ok(mut player) = query.get_mut(**current) {
         player.0 = 2;
     }
 }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Adds the support for marking entites and fetching them in queries
 
 ## Example
 
-View the whole example [here](examples/markers.rs)
+View more examples [here](examples/)
 
 ```rust
 #[derive(EntityMarker)]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+
+members = ["*"]
+exclude = ["target"]
+resolver = "2"

--- a/examples/custom_dyn_marker/Cargo.toml
+++ b/examples/custom_dyn_marker/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "custom_dyn_marker"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+bevy = "0.9.1"
+bevy_ecs_markers = { path = "../../", features = ["full_bevy"] }

--- a/examples/custom_dyn_marker/src/main.rs
+++ b/examples/custom_dyn_marker/src/main.rs
@@ -1,0 +1,39 @@
+use bevy::prelude::{App, Commands, Component, Query};
+use bevy_ecs_markers::{
+    params::{Marker, MarkerMut},
+    EntityMarker, InitMarkerData,
+};
+use players_data::PlayersMarkerData;
+
+mod players_data;
+
+pub struct Players;
+
+impl EntityMarker for Players {
+    type MarkerData = PlayersMarkerData;
+}
+
+#[derive(Component)]
+struct Player(u32);
+
+fn main() {
+    App::new()
+        .init_markerdata::<Players>()
+        .add_startup_system(setup)
+        .add_system(get_selected_player)
+        .run();
+}
+
+fn setup(mut commands: Commands, mut players: MarkerMut<Players>) {
+    let red = commands.spawn(Player(12)).id();
+    players.add(red);
+
+    let blue = commands.spawn(Player(7)).id();
+    players.add(blue);
+}
+
+fn get_selected_player(mut query: Query<&mut Player>, players: Marker<Players>) {
+    if let Ok(mut player) = query.get_mut(**players) {
+        player.0 = 2;
+    }
+}

--- a/examples/custom_dyn_marker/src/players_data.rs
+++ b/examples/custom_dyn_marker/src/players_data.rs
@@ -1,0 +1,33 @@
+use std::ops::Deref;
+
+use bevy::prelude::{Entity, Resource};
+use bevy_ecs_markers::SingleMarkerData;
+
+use crate::Players;
+
+#[derive(Resource, Default)]
+pub struct PlayersMarkerData(Vec<Entity>, usize);
+
+impl PlayersMarkerData {
+    pub fn add(&mut self, entity: Entity) {
+        self.0.push(entity)
+    }
+}
+
+impl SingleMarkerData<Players> for PlayersMarkerData {
+    fn get(&self) -> &Entity {
+        &self.0[self.1]
+    }
+
+    fn get_mut(&mut self) -> &mut Entity {
+        &mut self.0[self.1]
+    }
+}
+
+impl Deref for PlayersMarkerData {
+    type Target = Entity;
+
+    fn deref(&self) -> &Self::Target {
+        self.get()
+    }
+}

--- a/examples/markers.rs
+++ b/examples/markers.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::{App, Commands, Component, Query};
 use bevy_ecs_markers::{
     params::{Marker, MarkerMut},
-    EntityMarker, MarkerData,
+    EntityMarker,
 };
 
 #[derive(EntityMarker)]

--- a/examples/markers.rs
+++ b/examples/markers.rs
@@ -18,8 +18,8 @@ struct Player(u32);
 
 fn main() {
     App::new()
-        .init_resource::<MarkerData<Players>>()
-        .init_resource::<MarkerData<CurrentPlayer>>()
+        .init_resource::<<Players as EntityMarker>::MarkerData>()
+        .init_resource::<<CurrentPlayer as EntityMarker>::MarkerData>()
         .add_startup_system(setup)
         .add_system(get_red_player)
         .add_system(get_current_player)

--- a/examples/single_marker/Cargo.toml
+++ b/examples/single_marker/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "single_marker"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+bevy = "0.9.1"
+bevy_ecs_markers = { path = "../../", features = ["full_bevy"] }

--- a/examples/single_marker/src/main.rs
+++ b/examples/single_marker/src/main.rs
@@ -1,0 +1,33 @@
+use bevy::prelude::{App, Commands, Component, Query};
+use bevy_ecs_markers::{
+    params::{Marker, MarkerMut},
+    EntityMarker, InitMarkerData,
+};
+
+#[derive(EntityMarker)]
+struct CurrentPlayer;
+
+#[derive(Component)]
+struct Player(u32);
+
+fn main() {
+    App::new()
+        .init_markerdata::<CurrentPlayer>()
+        .add_startup_system(setup)
+        .add_system(get_current_player)
+        .run();
+}
+
+fn setup(mut commands: Commands, mut current: MarkerMut<CurrentPlayer>) {
+    let _red = commands.spawn(Player(12)).id();
+
+    let blue = commands.spawn(Player(7)).id();
+
+    *current = blue;
+}
+
+fn get_current_player(mut query: Query<&mut Player>, current: Marker<CurrentPlayer>) {
+    if let Ok(mut player) = query.get_mut(*current) {
+        player.0 = 2;
+    }
+}

--- a/examples/single_marker/src/main.rs
+++ b/examples/single_marker/src/main.rs
@@ -23,11 +23,11 @@ fn setup(mut commands: Commands, mut current: MarkerMut<CurrentPlayer>) {
 
     let blue = commands.spawn(Player(7)).id();
 
-    *current = blue;
+    **current = blue;
 }
 
 fn get_current_player(mut query: Query<&mut Player>, current: Marker<CurrentPlayer>) {
-    if let Ok(mut player) = query.get_mut(*current) {
+    if let Ok(mut player) = query.get_mut(**current) {
         player.0 = 2;
     }
 }

--- a/examples/value_marker/Cargo.toml
+++ b/examples/value_marker/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "value_marker"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+bevy = "0.9.1"
+bevy_ecs_markers = { path = "../../", features = ["full_bevy"] }

--- a/examples/value_marker/src/main.rs
+++ b/examples/value_marker/src/main.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::{App, Commands, Component, Query};
 use bevy_ecs_markers::{
     params::{Marker, MarkerMut},
-    EntityMarker,
+    EntityMarker, InitMarkerData,
 };
 
 #[derive(EntityMarker)]
@@ -10,44 +10,27 @@ enum Players {
     Blue,
 }
 
-#[derive(EntityMarker)]
-struct CurrentPlayer;
-
 #[derive(Component)]
 struct Player(u32);
 
 fn main() {
     App::new()
-        .init_resource::<<Players as EntityMarker>::MarkerData>()
-        .init_resource::<<CurrentPlayer as EntityMarker>::MarkerData>()
+        .init_markerdata::<Players>()
         .add_startup_system(setup)
         .add_system(get_red_player)
-        .add_system(get_current_player)
         .run();
 }
 
-fn setup(
-    mut commands: Commands,
-    mut markers: MarkerMut<Players>,
-    mut current: MarkerMut<CurrentPlayer>,
-) {
+fn setup(mut commands: Commands, mut markers: MarkerMut<Players>) {
     let red = commands.spawn(Player(12)).id();
     markers[Players::Red] = red;
 
     let blue = commands.spawn(Player(7)).id();
     markers[Players::Blue] = blue;
-
-    *current = blue;
 }
 
 fn get_red_player(mut query: Query<&mut Player>, markers: Marker<Players>) {
     if let Ok(mut player) = query.get_mut(markers[Players::Red]) {
         player.0 = 15;
-    }
-}
-
-fn get_current_player(mut query: Query<&mut Player>, current: Marker<CurrentPlayer>) {
-    if let Ok(mut player) = query.get_mut(*current) {
-        player.0 = 2;
     }
 }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_ecs_markers_macros"
-version = "0.1.4"
+version = "1.0.0"
 edition = "2021"
 authors = ["DasLixou"]
 description = "Proc Macros for Bevy ECS Markers"

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -53,6 +53,24 @@ pub fn entity_marker_derive(input: TokenStream) -> TokenStream {
                     }
                 }
 
+                impl std::ops::Deref for #marker_name {
+                    type Target = #entity_path;
+
+                    #[inline(always)]
+                    fn deref(&self) -> &Self::Target {
+                        use bevy_ecs_markers::SingleMarkerData;
+                        self.get()
+                    }
+                }
+
+                impl std::ops::DerefMut for #marker_name {
+                    #[inline(always)]
+                    fn deref_mut(&mut self) -> &mut Self::Target {
+                        use bevy_ecs_markers::SingleMarkerData;
+                        self.get_mut()
+                    }
+                }
+
                 impl Default for #marker_name {
                     #[inline(always)]
                     fn default() -> Self {
@@ -111,6 +129,24 @@ pub fn entity_marker_derive(input: TokenStream) -> TokenStream {
                         match key {
                             #arms
                         }
+                    }
+                }
+
+                impl std::ops::Index<#name> for #marker_name {
+                    type Output = #entity_path;
+
+                    #[inline(always)]
+                    fn index(&self, index: #name) -> &Self::Output {
+                        use bevy_ecs_markers::ValueMarkerData;
+                        self.value(index)
+                    }
+                }
+
+                impl std::ops::IndexMut<#name> for #marker_name {
+                    #[inline(always)]
+                    fn index_mut(&mut self, index: #name) -> &mut Self::Output {
+                        use bevy_ecs_markers::ValueMarkerData;
+                        self.value_mut(index)
                     }
                 }
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -19,6 +19,8 @@ pub fn entity_marker_derive(input: TokenStream) -> TokenStream {
         type MarkerData = #marker_name;
     };
 
+    // BEGIN Some useful declarations
+
     let mut entity_path = bevy_ecs_path();
     entity_path.segments.push(format_ident!("entity").into());
     entity_path.segments.push(format_ident!("Entity").into());
@@ -28,6 +30,10 @@ pub fn entity_marker_derive(input: TokenStream) -> TokenStream {
     resource_path
         .segments
         .push(format_ident!("Resource").into());
+
+    let placeholder = quote! { #entity_path::from_raw(u32::MAX) }; // TODO: use Entity::PLACEHOLDER when released
+
+    // END
 
     let marker_data = match &input.data {
         syn::Data::Struct(_) => {
@@ -50,7 +56,7 @@ pub fn entity_marker_derive(input: TokenStream) -> TokenStream {
                 impl Default for #marker_name {
                     #[inline(always)]
                     fn default() -> Self {
-                        Self(#entity_path::from_raw(u32::MAX)) // TODO: use Entity::PLACEHOLDER when released
+                        Self(#placeholder)
                     }
                 }
             }
@@ -77,7 +83,7 @@ pub fn entity_marker_derive(input: TokenStream) -> TokenStream {
                 impl Default for #marker_name {
                     #[inline(always)]
                     fn default() -> Self {
-                        Self([#entity_path::from_raw(u32::MAX); #capacity]) // TODO: use Entity::PLACEHOLDER when released
+                        Self([#placeholder; #capacity])
                     }
                 }
             }

--- a/src/entity_marker.rs
+++ b/src/entity_marker.rs
@@ -19,3 +19,9 @@ pub trait EntityMarker: Sync + Send {
 
     fn unit_index(&self) -> usize;
 }
+
+pub trait DynamicEntityMarker: EntityMarker {
+    fn add(storage: &mut Self::Storage, entity: Entity)
+    where
+        Self: Sized;
+}

--- a/src/entity_marker.rs
+++ b/src/entity_marker.rs
@@ -3,7 +3,7 @@ use bevy_ecs::{entity::Entity, system::Resource};
 pub trait EntityMarker: Sync + Send {
     const PLACEHOLDER: Entity = Entity::from_raw(u32::MAX); // TODO: use Entity::PLACEHOLDER when released
 
-    type MarkerData: Resource;
+    type MarkerData: Resource + Default;
 
     fn new_data() -> Self::MarkerData
     where

--- a/src/entity_marker.rs
+++ b/src/entity_marker.rs
@@ -1,5 +1,9 @@
 use bevy_ecs::system::Resource;
 
+/// Defines which MarkerData to use for this EntityMarker
+///
+/// ## Hint
+/// `#[derive(EntityMarker)]` automaticly creates and links a matching MarkerData type for the type to which the derive is applied to.
 pub trait EntityMarker: Sync + Send {
     type MarkerData: Resource + Default;
 }

--- a/src/entity_marker.rs
+++ b/src/entity_marker.rs
@@ -1,27 +1,13 @@
-use std::ops::{Index, IndexMut};
-
-use bevy_ecs::entity::Entity;
-
-use crate::MarkerData;
+use bevy_ecs::{entity::Entity, system::Resource};
 
 pub trait EntityMarker: Sync + Send {
     const PLACEHOLDER: Entity = Entity::from_raw(u32::MAX); // TODO: use Entity::PLACEHOLDER when released
 
-    type Storage: Index<usize, Output = Entity> + IndexMut<usize> + Send + Sync;
+    type MarkerData: Resource;
 
-    fn create_storage() -> Self::Storage
-    where
-        Self: Sized;
-
-    fn new_data() -> MarkerData<Self>
+    fn new_data() -> Self::MarkerData
     where
         Self: Sized;
 
     fn unit_index(&self) -> usize;
-}
-
-pub trait DynamicEntityMarker: EntityMarker {
-    fn add(storage: &mut Self::Storage, entity: Entity)
-    where
-        Self: Sized;
 }

--- a/src/entity_marker.rs
+++ b/src/entity_marker.rs
@@ -2,6 +2,4 @@ use bevy_ecs::system::Resource;
 
 pub trait EntityMarker: Sync + Send {
     type MarkerData: Resource + Default;
-
-    fn unit_index(&self) -> usize;
 }

--- a/src/entity_marker.rs
+++ b/src/entity_marker.rs
@@ -1,8 +1,6 @@
-use bevy_ecs::{entity::Entity, system::Resource};
+use bevy_ecs::system::Resource;
 
 pub trait EntityMarker: Sync + Send {
-    const PLACEHOLDER: Entity = Entity::from_raw(u32::MAX); // TODO: use Entity::PLACEHOLDER when released
-
     type MarkerData: Resource + Default;
 
     fn unit_index(&self) -> usize;

--- a/src/entity_marker.rs
+++ b/src/entity_marker.rs
@@ -5,9 +5,5 @@ pub trait EntityMarker: Sync + Send {
 
     type MarkerData: Resource + Default;
 
-    fn new_data() -> Self::MarkerData
-    where
-        Self: Sized;
-
     fn unit_index(&self) -> usize;
 }

--- a/src/init_markerdata.rs
+++ b/src/init_markerdata.rs
@@ -7,6 +7,7 @@ pub trait InitMarkerData {
 }
 
 impl InitMarkerData for World {
+    #[inline(always)]
     fn init_markerdata<M: EntityMarker>(&mut self) -> &mut Self {
         self.init_resource::<M::MarkerData>();
         self
@@ -15,6 +16,7 @@ impl InitMarkerData for World {
 
 #[cfg(feature = "full_bevy")]
 impl InitMarkerData for bevy::prelude::App {
+    #[inline(always)]
     fn init_markerdata<M: EntityMarker>(&mut self) -> &mut Self {
         self.init_resource::<M::MarkerData>();
         self

--- a/src/init_markerdata.rs
+++ b/src/init_markerdata.rs
@@ -1,0 +1,22 @@
+use bevy_ecs::world::World;
+
+use crate::EntityMarker;
+
+pub trait InitMarkerData {
+    fn init_markerdata<M: EntityMarker>(&mut self) -> &mut Self;
+}
+
+impl InitMarkerData for World {
+    fn init_markerdata<M: EntityMarker>(&mut self) -> &mut Self {
+        self.init_resource::<M::MarkerData>();
+        self
+    }
+}
+
+#[cfg(feature = "full_bevy")]
+impl InitMarkerData for bevy::prelude::App {
+    fn init_markerdata<M: EntityMarker>(&mut self) -> &mut Self {
+        self.init_resource::<M::MarkerData>();
+        self
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,14 @@
 //!
 //! # Features
 //! - **proc** *(default)* &mdash; re-exports procedual macros from `bevy_ecs_markers_macros`
+//! - **full_bevy** &mdash; Uses full bevy engine and add helpers for it.
 mod entity_marker;
+mod init_markerdata;
 mod marker_data;
 pub mod params;
 
 pub use entity_marker::*;
+pub use init_markerdata::*;
 pub use marker_data::*;
 
 #[cfg(feature = "proc")]

--- a/src/marker_data.rs
+++ b/src/marker_data.rs
@@ -10,6 +10,10 @@ pub trait SingleMarkerData<M: EntityMarker> {
 pub trait ValueMarkerData<M: EntityMarker> {
     fn value(&self, key: M) -> &Entity;
     fn value_mut(&mut self, key: M) -> &mut Entity;
+
+    fn unit_index(key: M) -> usize
+    where
+        Self: Sized;
 }
 
 pub trait DynMarkerData<M: EntityMarker> {

--- a/src/marker_data.rs
+++ b/src/marker_data.rs
@@ -1,52 +1,17 @@
-use bevy_ecs::{entity::Entity, system::Resource};
+use bevy_ecs::entity::Entity;
 
-use crate::{entity_marker::EntityMarker, DynamicEntityMarker};
+use crate::entity_marker::EntityMarker;
 
-/// This is the container which stores all IDs from [`Entity`] in it
-#[derive(Resource)]
-pub struct MarkerData<M: EntityMarker> {
-    data: M::Storage,
+pub trait SingleMarkerData<M: EntityMarker> {
+    fn get(&self) -> &Entity;
+    fn get_mut(&mut self) -> &mut Entity;
 }
 
-impl<M: EntityMarker> Default for MarkerData<M> {
-    #[inline(always)]
-    fn default() -> Self {
-        M::new_data()
-    }
+pub trait ValueMarkerData<M: EntityMarker> {
+    fn value(&self, key: M) -> &Entity;
+    fn value_mut(&mut self, key: M) -> &mut Entity;
 }
 
-impl<M: EntityMarker> MarkerData<M> {
-    #[inline(always)]
-    pub fn new() -> Self {
-        Self {
-            data: M::create_storage(),
-        }
-    }
-
-    #[inline(always)]
-    pub fn value(&self, key: M) -> &Entity {
-        &self.data[key.unit_index()]
-    }
-
-    #[inline(always)]
-    pub fn value_mut(&mut self, key: M) -> &mut Entity {
-        &mut self.data[key.unit_index()]
-    }
-
-    #[inline(always)]
-    pub fn get(&self) -> &Entity {
-        &self.data[0]
-    }
-
-    #[inline(always)]
-    pub fn get_mut(&mut self) -> &mut Entity {
-        &mut self.data[0]
-    }
-}
-
-impl<M: EntityMarker + DynamicEntityMarker> MarkerData<M> {
-    #[inline(always)]
-    pub fn add(&mut self, entity: Entity) {
-        M::add(&mut self.data, entity);
-    }
+pub trait DynMarkerData<M: EntityMarker> {
+    fn add(&mut self, entity: Entity);
 }

--- a/src/marker_data.rs
+++ b/src/marker_data.rs
@@ -2,11 +2,13 @@ use bevy_ecs::entity::Entity;
 
 use crate::entity_marker::EntityMarker;
 
+/// This trait is used for MarkerData when it only holds one [`Entity`]
 pub trait SingleMarkerData<M: EntityMarker> {
     fn get(&self) -> &Entity;
     fn get_mut(&mut self) -> &mut Entity;
 }
 
+/// This trait is used for MarkerData when it holds multiple of [`Entity`] and can be retrieved by a key
 pub trait ValueMarkerData<M: EntityMarker> {
     fn value(&self, key: M) -> &Entity;
     fn value_mut(&mut self, key: M) -> &mut Entity;

--- a/src/marker_data.rs
+++ b/src/marker_data.rs
@@ -1,6 +1,6 @@
 use bevy_ecs::{entity::Entity, system::Resource};
 
-use crate::entity_marker::EntityMarker;
+use crate::{entity_marker::EntityMarker, DynamicEntityMarker};
 
 /// This is the container which stores all IDs from [`Entity`] in it
 #[derive(Resource)]
@@ -41,5 +41,12 @@ impl<M: EntityMarker> MarkerData<M> {
     #[inline(always)]
     pub fn get_mut(&mut self) -> &mut Entity {
         &mut self.data[0]
+    }
+}
+
+impl<M: EntityMarker + DynamicEntityMarker> MarkerData<M> {
+    #[inline(always)]
+    pub fn add(&mut self, entity: Entity) {
+        M::add(&mut self.data, entity);
     }
 }

--- a/src/marker_data.rs
+++ b/src/marker_data.rs
@@ -2,7 +2,7 @@ use bevy_ecs::entity::Entity;
 
 use crate::entity_marker::EntityMarker;
 
-/// This trait is used for MarkerData when it only holds one [`Entity`]
+/// This trait is used for MarkerData when it only holds one [`Entity`] or has a selection from [`SelectableMarkerData`]
 pub trait SingleMarkerData<M: EntityMarker> {
     fn get(&self) -> &Entity;
     fn get_mut(&mut self) -> &mut Entity;
@@ -16,8 +16,4 @@ pub trait ValueMarkerData<M: EntityMarker> {
     fn unit_index(key: M) -> usize
     where
         Self: Sized;
-}
-
-pub trait DynMarkerData<M: EntityMarker> {
-    fn add(&mut self, entity: Entity);
 }

--- a/src/params/marker.rs
+++ b/src/params/marker.rs
@@ -4,17 +4,21 @@ use std::{marker::PhantomData, ops::Index};
 use bevy_ecs::prelude::Entity;
 use bevy_ecs::system::{Res, SystemParam};
 
-use crate::{entity_marker::EntityMarker, marker_data::MarkerData};
+use crate::entity_marker::EntityMarker;
+use crate::{SingleMarkerData, ValueMarkerData};
 
 /// A System Param that can read the data from a given [`EntityMarker`]
 #[derive(SystemParam)]
 pub struct Marker<'s, 'w, M: EntityMarker + 'static> {
-    marker_data: Res<'w, MarkerData<M>>,
+    marker_data: Res<'w, M::MarkerData>,
     #[system_param(ignore)]
     phantom: PhantomData<&'s ()>,
 }
 
-impl<'s, 'w, M: EntityMarker + 'static> Index<M> for Marker<'s, 'w, M> {
+impl<'s, 'w, M: EntityMarker + 'static> Index<M> for Marker<'s, 'w, M>
+where
+    M::MarkerData: ValueMarkerData<M>,
+{
     type Output = Entity;
 
     #[inline(always)]
@@ -23,7 +27,10 @@ impl<'s, 'w, M: EntityMarker + 'static> Index<M> for Marker<'s, 'w, M> {
     }
 }
 
-impl<'s, 'w, M: EntityMarker + 'static> Deref for Marker<'s, 'w, M> {
+impl<'s, 'w, M: EntityMarker + 'static> Deref for Marker<'s, 'w, M>
+where
+    M::MarkerData: SingleMarkerData<M>,
+{
     type Target = Entity;
 
     #[inline(always)]

--- a/src/params/marker.rs
+++ b/src/params/marker.rs
@@ -1,11 +1,9 @@
+use std::marker::PhantomData;
 use std::ops::Deref;
-use std::{marker::PhantomData, ops::Index};
 
-use bevy_ecs::prelude::Entity;
 use bevy_ecs::system::{Res, SystemParam};
 
 use crate::entity_marker::EntityMarker;
-use crate::{SingleMarkerData, ValueMarkerData};
 
 /// A System Param that can read the data from a given [`EntityMarker`]
 #[derive(SystemParam)]
@@ -15,26 +13,11 @@ pub struct Marker<'s, 'w, M: EntityMarker + 'static> {
     phantom: PhantomData<&'s ()>,
 }
 
-impl<'s, 'w, M: EntityMarker + 'static> Index<M> for Marker<'s, 'w, M>
-where
-    M::MarkerData: ValueMarkerData<M>,
-{
-    type Output = Entity;
-
-    #[inline(always)]
-    fn index(&self, index: M) -> &Self::Output {
-        self.marker_data.value(index)
-    }
-}
-
-impl<'s, 'w, M: EntityMarker + 'static> Deref for Marker<'s, 'w, M>
-where
-    M::MarkerData: SingleMarkerData<M>,
-{
-    type Target = Entity;
+impl<'s, 'w, M: EntityMarker + 'static> Deref for Marker<'s, 'w, M> {
+    type Target = M::MarkerData;
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.marker_data.get()
+        &*self.marker_data
     }
 }

--- a/src/params/marker_mut.rs
+++ b/src/params/marker_mut.rs
@@ -1,11 +1,9 @@
-use std::ops::{Deref, DerefMut, IndexMut};
-use std::{marker::PhantomData, ops::Index};
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
 
-use bevy_ecs::prelude::Entity;
 use bevy_ecs::system::{ResMut, SystemParam};
 
 use crate::entity_marker::EntityMarker;
-use crate::{DynMarkerData, SingleMarkerData, ValueMarkerData};
 
 /// A System Param that can read and modify the data from a given [`EntityMarker`]
 #[derive(SystemParam)]
@@ -15,56 +13,18 @@ pub struct MarkerMut<'s, 'w, M: EntityMarker + 'static> {
     phantom: PhantomData<&'s ()>,
 }
 
-impl<'s, 'w, M: EntityMarker + 'static> MarkerMut<'s, 'w, M>
-where
-    M::MarkerData: DynMarkerData<M>,
-{
-    #[inline(always)]
-    pub fn add(&mut self, entity: Entity) {
-        self.marker_data.add(entity);
-    }
-}
-
-impl<'s, 'w, M: EntityMarker + 'static> Index<M> for MarkerMut<'s, 'w, M>
-where
-    M::MarkerData: ValueMarkerData<M>,
-{
-    type Output = Entity;
-
-    #[inline(always)]
-    fn index(&self, index: M) -> &Self::Output {
-        self.marker_data.value(index)
-    }
-}
-
-impl<'s, 'w, M: EntityMarker + 'static> IndexMut<M> for MarkerMut<'s, 'w, M>
-where
-    M::MarkerData: ValueMarkerData<M>,
-{
-    #[inline(always)]
-    fn index_mut(&mut self, index: M) -> &mut Self::Output {
-        self.marker_data.value_mut(index)
-    }
-}
-
-impl<'s, 'w, M: EntityMarker + 'static> Deref for MarkerMut<'s, 'w, M>
-where
-    M::MarkerData: SingleMarkerData<M>,
-{
-    type Target = Entity;
+impl<'s, 'w, M: EntityMarker + 'static> Deref for MarkerMut<'s, 'w, M> {
+    type Target = M::MarkerData;
 
     #[inline(always)]
     fn deref(&self) -> &Self::Target {
-        self.marker_data.get()
+        &*self.marker_data
     }
 }
 
-impl<'s, 'w, M: EntityMarker + 'static> DerefMut for MarkerMut<'s, 'w, M>
-where
-    M::MarkerData: SingleMarkerData<M>,
-{
+impl<'s, 'w, M: EntityMarker + 'static> DerefMut for MarkerMut<'s, 'w, M> {
     #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.marker_data.get_mut()
+        &mut *self.marker_data
     }
 }

--- a/src/params/marker_mut.rs
+++ b/src/params/marker_mut.rs
@@ -4,6 +4,7 @@ use std::{marker::PhantomData, ops::Index};
 use bevy_ecs::prelude::Entity;
 use bevy_ecs::system::{ResMut, SystemParam};
 
+use crate::DynamicEntityMarker;
 use crate::{entity_marker::EntityMarker, marker_data::MarkerData};
 
 /// A System Param that can read and modify the data from a given [`EntityMarker`]
@@ -12,6 +13,13 @@ pub struct MarkerMut<'s, 'w, M: EntityMarker + 'static> {
     marker_data: ResMut<'w, MarkerData<M>>,
     #[system_param(ignore)]
     phantom: PhantomData<&'s ()>,
+}
+
+impl<'s, 'w, M: EntityMarker + DynamicEntityMarker + 'static> MarkerMut<'s, 'w, M> {
+    #[inline(always)]
+    pub fn add(&mut self, entity: Entity) {
+        self.marker_data.add(entity);
+    }
 }
 
 impl<'s, 'w, M: EntityMarker + 'static> Index<M> for MarkerMut<'s, 'w, M> {


### PR DESCRIPTION
* Split up MarkerData in smaller and custom traits
* Add `init_markerdata` helpers
* Move `unit_index` to `ValueMarkerData` exclusively
* Restructure examples
* Add new examples
* Remove inline functions from `Marker` and `MarkerMut`, just `Deref` to the provided `MarkerData`
* Add possibility to make custom MarkerData traits